### PR TITLE
Create a new function to run multiple instances of torcs

### DIFF
--- a/a3c/agent.py
+++ b/a3c/agent.py
@@ -11,7 +11,7 @@ class A3C_Agent(Process):
         super(A3C_Agent, self).__init__()
         self.network = A3C_Network(29, 3, lock)
         self.global_net = global_net
-        self.name = f'Process_{rank}' 
+        self.name = f'Process_{rank}'
         self.counter = counter
         self.lock = lock
         self.opt = opt

--- a/a3c/snakeoil3_gym.py
+++ b/a3c/snakeoil3_gym.py
@@ -115,7 +115,7 @@ def bargraph(x,mn,mx,w,c='X'):
     return '[%s]' % (nnc+npc+ppc+pnc)
 
 class Client():
-    def __init__(self,H=None,p=None,i=None,e=None,t=None,s=None,d=None,vision=False):
+    def __init__(self,relaunch_torcs,H=None,p=None,i=None,e=None,t=None,s=None,d=None,vision=False):
         # If you don't like the option defaults,  change them here.
         self.vision = vision
 
@@ -127,6 +127,7 @@ class Client():
         self.stage= 3 # 0=Warm-up, 1=Qualifying 2=Race, 3=unknown <Default=3>
         self.debug= False
         self.maxSteps= 100000  # 50steps/second
+        self.relaunch_torcs = relaunch_torcs
         self.parse_the_command_line()
         if H: self.host= H
         if p: self.port= p
@@ -171,15 +172,19 @@ class Client():
                 # print("Count Down : " + str(n_fail))
                 if n_fail < 0:
                     # print("relaunch torcs")
-                    os.system('pkill torcs')
-                    time.sleep(1.0)
-                    if self.vision is False:
-                        os.system(f'torcs -nofuel -nodamage -nolaptime -p {self.port} &')
-                    else:
-                        os.system(f'torcs -nofuel -nodamage -nolaptime -vision -p {self.port} &')
 
-                    time.sleep(1.0)
-                    os.system('sh autostart.sh')
+                    self.relaunch_torcs()
+
+
+                    # os.system('pkill torcs')
+                    # time.sleep(1.0)
+                    # if self.vision is False:
+                    #     os.system(f'torcs -nofuel -nodamage -nolaptime -p {self.port} &')
+                    # else:
+                    #     os.system(f'torcs -nofuel -nodamage -nolaptime -vision -p {self.port} &')
+                    #
+                    # time.sleep(1.0)
+                    # os.system('sh autostart.sh')
                     n_fail = 5
                 n_fail -= 1
 


### PR DESCRIPTION
Previously, to create new torcs process, shell scritpts were used with `os.system`. Now it is changed to using `start_torcs_process` function which uses `subprocess.Popen`.